### PR TITLE
Fixing repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ or to install directly from GitHub:
 ```r
 install.packages("devtools")
 library(devtools)
-install_github("neksa/MethylToSNP")
+install_github("elnitskilab/MethylToSNP")
 ```
 
 


### PR DESCRIPTION
Currently pointing to the old version. Going to neksa/MethylToSNP gives a 404.